### PR TITLE
Fixed issue in getDate function

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '18.x'
+      - run: export TZ='America/Guayaquil' # date getter function tests are dependent on timezone
       - run: npm ci
       - run: npm run build
       - run: npm run test

--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -14,6 +14,7 @@ jobs:
         with:
           node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
+      - run: export TZ='America/Guayaquil' # date getter function tests are dependent on timezone
       - run: npm ci
       - run: npm run build
       - run: npm run test

--- a/ec-sri-invoice-signer/src/utils/utils.ts
+++ b/ec-sri-invoice-signer/src/utils/utils.ts
@@ -18,7 +18,7 @@ const getDate = (): string => {
   const offsetMinutes = offsetRelativeToUTCInMinutes % 60;
   const formattedOffset = `${offsetRelativeToUTCInMinutes > 0 ? '-' : '+'}${String(Math.abs(offsetHours)).padStart(2, '0')}:${String(Math.abs(offsetMinutes)).padStart(2, '0')}`;
 
-  return new Date(date.getTime() + offsetRelativeToUTCInMinutes * 60 * 1000).toISOString().replace('Z', formattedOffset);
+  return new Date(date.getTime() - offsetRelativeToUTCInMinutes * 60 * 1000).toISOString().replace('Z', formattedOffset);
 }
 
 export default {

--- a/ec-sri-invoice-signer/test/utils/utils.test.ts
+++ b/ec-sri-invoice-signer/test/utils/utils.test.ts
@@ -1,5 +1,6 @@
-import { expect } from "chai";
-import Utils from "../../src/utils/utils";
+import { expect } from 'chai';
+import Utils from '../../src/utils/utils';
+import sinon, { SinonFakeTimers } from 'sinon';
 
 describe('Given the getRandomInt function', () => {
   it('should return a random UUID v4', () => {
@@ -9,8 +10,22 @@ describe('Given the getRandomInt function', () => {
 });
 
 describe('Given the getDate function', () => {
+  let clock: SinonFakeTimers;
+
+  afterEach(() => {
+    clock?.restore();
+  });
+
   it('should return the current date correctly formatted', () => {
     const result = Utils.getDate();
     expect(/^20\d{2}-[0-3]\d-[0-3]\dT[0-2]\d:[0-6]\d:[0-6]\d\.\d{3}[-+][0-2]\d:[0-6]\d$/.test(result)).to.be.true;
+  });
+
+  it('should return the current date in local time', () => {
+    clock = sinon.useFakeTimers({ now: 1694787394044 }); // 2023-09-15T14:16:34.044Z
+    const result = Utils.getDate();
+    // UTC-5. America/Guayaquil timezone is set in the server. Configure this locally if you are in a different timezone and
+    // want to run this test reliably
+    expect(result).to.equal('2023-09-15T09:16:34.044-05:00');
   });
 });


### PR DESCRIPTION
### Content
- Typo fix (`+` -> `-`) that caused the local time offset to be added with the opposite sign than the expected.
- Test to cover the issue.
- CI/CD scripts update to set a fixed timezone before running the tests (America/Guayaquil). 