### PR TITLE
fix: corregir los valores invertidos de modulus y exponent en extractPrivateKeyData

### DIFF
--- a/ec-sri-invoice-signer/src/utils/cryptography.ts
+++ b/ec-sri-invoice-signer/src/utils/cryptography.ts
@@ -112,8 +112,8 @@ const extractX509Data = (certificate: forge.pki.Certificate) => {
 }
 
 const extractPrivateKeyData = (privateKey: forge.pki.rsa.PrivateKey) => {
-  const modulus = Buffer.from(privateKey.e.toString(), 'hex').toString('base64');
-  const exponent = Buffer.from(privateKey.n.toString(), 'hex').toString('base64');
+  const modulus = Buffer.from(privateKey.n.toString(), 'hex').toString('base64');
+  const exponent = Buffer.from(privateKey.e.toString(), 'hex').toString('base64');
 
   return {
     modulus,
@@ -128,4 +128,5 @@ export {
   extractPrivateKeyData,
   extractIssuerData,
   extractX509Data
+
 }


### PR DESCRIPTION
Antes, la función usaba privateKey.e como modulus y privateKey.n como exponent, lo cual era incorrecto. Ahora los valores se asignan correctamente: privateKey.n corresponde al modulus y privateKey.e al exponent.