### PR TITLE
Security patch and version bump

### DIFF
--- a/ec-sri-invoice-signer/package-lock.json
+++ b/ec-sri-invoice-signer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ec-sri-invoice-signer",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ec-sri-invoice-signer",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "fast-xml-parser": "^4.2.5",
@@ -4145,9 +4145,10 @@
       "license": "MIT"
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.2.tgz",
+      "integrity": "sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
       }
@@ -8076,9 +8077,9 @@
       "dev": true
     },
     "node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.2.tgz",
+      "integrity": "sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/ec-sri-invoice-signer/package.json
+++ b/ec-sri-invoice-signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ec-sri-invoice-signer",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Ecuador SRI invoice signer.",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
This pull request updates the `ec-sri-invoice-signer` package to version 1.6.1 and bumps the `node-forge` dependency to address high severity security issue. The changes are limited to version updates in the package metadata and lockfile.

Dependency and version updates:

* Bumped the package version from `1.6.0` to `1.6.1` in both `package.json` and `package-lock.json` to reflect a new release. [[1]](diffhunk://#diff-dbae40eae4d8026cc5b4e842d0e4ff2bfacc082e9a4ac6052564ff1aa901392dL3-R3) [[2]](diffhunk://#diff-c953d1c1215ff661f1cd6f83cc862388dee6233e1c143fc2eb6eed6c4e19e30cL3-R9)
* Upgraded the `node-forge` dependency from version `1.3.1` to `1.3.2` in `package-lock.json`, including updated integrity hashes and license information. [[1]](diffhunk://#diff-c953d1c1215ff661f1cd6f83cc862388dee6233e1c143fc2eb6eed6c4e19e30cL4148-R4151) [[2]](diffhunk://#diff-c953d1c1215ff661f1cd6f83cc862388dee6233e1c143fc2eb6eed6c4e19e30cL8079-R8082)